### PR TITLE
PF-475 - Made the SxS Pro plugin more configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,29 @@ An AQTS field data plugin for AQTS 2018.2-or-newer systems, which can read disch
 ## Want to install this plugin?
 
 - Download the latest release of the plugin [here](../../releases/latest)
-- Install it using the [FieldVisitPluginTool](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/src/FieldDataPluginTool)
+- Install it on AQTS 2019.2-or-newer via the System Configuration page
+- Install it on AQTS 2019.1-or-older using the [FieldVisitPluginTool](https://github.com/AquaticInformatics/aquarius-field-data-framework/tree/master/src/FieldDataPluginTool)
 
 ## Requirements for building the plugin from source
 
 - Requires Visual Studio 2017 (Community Edition is fine)
 - .NET 4.7 runtime
+
+## Configuring the plugin
+
+The format of SxS Pro XML files consumed by this plugin can vary from based on the SxS Pro user's regional settings for times and dates.
+
+The SxS Pro software will generate different XML for US users vs. UK users.
+
+Consider April Fool's Day, 2019 (an example date which ironically exposes the foolish bug).
+
+US XML files will contain `<Date>4/1/2019</Date>`, but XML files saved in Great Britain wil contain `<Date>01/04/2019</Date>`.
+
+Since the plugin runs on the AQTS server, it does not know which date format to expect, so the plugin must be configured with what to expect.
+
+Should it prefer month/day/year (US-style) or day/month/year (UK-style)?
+
+See the [Configuration page](src/SxSPro/Readme.md) for details.
 
 ## Building the plugin
 

--- a/src/SxSPro/Config.cs
+++ b/src/SxSPro/Config.cs
@@ -1,0 +1,8 @@
+﻿namespace SxSPro
+{
+    public class Config
+    {
+        public string[] DateFormats { get; set; }
+        public string[] TimeFormats { get; set; }
+    }
+}

--- a/src/SxSPro/Config.json
+++ b/src/SxSPro/Config.json
@@ -1,0 +1,4 @@
+﻿{
+  "DateFormats": [ "M/d/yyyy", "M-d-yyyy", "yyyy/M/d", "yyyy-M-d" ],
+  "TimeFormats": [ "h:m:s tt", "h:m tt", "H:m:s", "H:m" ]
+}

--- a/src/SxSPro/ConfigLoader.cs
+++ b/src/SxSPro/ConfigLoader.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using ServiceStack;
+
+namespace SxSPro
+{
+    public class ConfigLoader
+    {
+        public Config Load(string path)
+        {
+            if (!File.Exists(path))
+                return Sanitize(new Config());
+
+            try
+            {
+                return Sanitize(File.ReadAllText(path)
+                    .FromJson<Config>());
+            }
+            catch (SerializationException exception)
+            {
+                throw new ArgumentException($"'{path}' is not a valid Config JSON file.", exception);
+            }
+        }
+
+        private Config Sanitize(Config config)
+        {
+            config.DateFormats = SanitizeList(config.DateFormats, "M/d/yyyy", "M-d-yyyy", "yyyy/M/d", "yyyy-M-d");
+            config.TimeFormats = SanitizeList(config.TimeFormats, "h:m tt", "h:m:s tt");
+
+            foreach (var pattern in config.DateFormats)
+            {
+                ThrowIfInvalidDateFormat(pattern);
+            }
+
+            var leadingMonthPatterns = config.DateFormats.Where(IsLeadingMonthPattern).ToList();
+            var leadingDayPatterns = config.DateFormats.Where(IsLeadingDayPattern).ToList();
+
+            if (leadingMonthPatterns.Any() && leadingDayPatterns.Any())
+            {
+                throw new ArgumentException($"Ambiguous {nameof(config.DateFormats)}: Day-then-month patterns ({string.Join(", ", leadingDayPatterns)}) conflict with Month-then-day patterns ({string.Join(", ", leadingMonthPatterns)})");
+            }
+
+            foreach (var pattern in config.TimeFormats)
+            {
+                ThrowIfInvalidTimeFormat(pattern);
+            }
+
+            return config;
+        }
+
+        private static string[] SanitizeList(IList<string> list, params string[] defaultIfEmpty)
+        {
+            if (defaultIfEmpty == null || defaultIfEmpty.Length == 0)
+                throw new ArgumentException("Can't be empty", nameof(defaultIfEmpty));
+
+            if (list == null)
+            {
+                list = new List<string>();
+            }
+
+            list = list
+                .Select(s => s.Trim())
+                .Where(s => !string.IsNullOrEmpty(s))
+                .ToList();
+
+            if (!list.Any())
+            {
+                foreach (var s in defaultIfEmpty)
+                {
+                    list.Add(s);
+                }
+            }
+
+            return list.ToArray();
+        }
+
+        private bool IsLeadingMonthPattern(string pattern)
+        {
+            return pattern.StartsWith("M");
+        }
+
+        private bool IsLeadingDayPattern(string pattern)
+        {
+            return pattern.StartsWith("d");
+        }
+
+        private void ThrowIfInvalidDateFormat(string pattern)
+        {
+            ThrowIfInvalidFormat("DateFormat", pattern, s => s.Contains("m"), "Only use uppercase 'M' (months), not lowercase 'm' (minutes)");
+            ThrowIfInvalidFormat("DateFormat", pattern, s => !s.Contains("yy"), "A 'yyyy' or 'yy' (year) pattern is missing.");
+            ThrowIfInvalidFormat("DateFormat", pattern, s => !s.Contains("M"), "A 'M' (month) pattern is missing.");
+            ThrowIfInvalidFormat("DateFormat", pattern, s => !s.Contains("d"), "A 'd' (ray) pattern is missing.");
+        }
+
+        private void ThrowIfInvalidTimeFormat(string pattern)
+        {
+            ThrowIfInvalidFormat("TimeFormat", pattern, s => s.Contains("M"), "Only use lowercase 'm' (minutes), not uppercase 'M' (months)");
+            ThrowIfInvalidFormat("TimeFormat", pattern, s => !s.Contains("m"), "A 'm' (minutes) pattern is missing.");
+            ThrowIfInvalidFormat("TimeFormat", pattern, s => !(s.Contains("h") && s.Contains("tt")) && !s.Contains("H"), "A 'H' (24-hour) or 'h' and 'tt' (12 hour plus AM/PM) pattern is missing.");
+            ThrowIfInvalidFormat("TimeFormat", pattern, s => s.Contains("H") && s.Contains("tt"), "Can't mix 'H' (24 hour) with 'tt' (AM/PM)");
+            ThrowIfInvalidFormat("TimeFormat", pattern, s => s.Contains("h") && !s.Contains("tt"), "Only us 'h' (12-hour) with 'tt' (AM/PM)");
+        }
+
+        private void ThrowIfInvalidFormat(string formatName, string pattern, Func<string, bool> invalidPredicate, string message)
+        {
+            if (invalidPredicate(pattern))
+                throw new ArgumentException($"'{pattern}' is not a valid {formatName} string. {message}");
+        }
+    }
+}

--- a/src/SxSPro/Mappers/DischargeActivityMapper.cs
+++ b/src/SxSPro/Mappers/DischargeActivityMapper.cs
@@ -1,4 +1,5 @@
-﻿using FieldDataPluginFramework.Context;
+﻿using System;
+using FieldDataPluginFramework.Context;
 using FieldDataPluginFramework.DataModel;
 using FieldDataPluginFramework.DataModel.ChannelMeasurements;
 using FieldDataPluginFramework.DataModel.DischargeActivities;
@@ -44,6 +45,7 @@ namespace SxSPro.Mappers
 
             dischargeActivity.Comments = sxsSummary.Comments;
             dischargeActivity.Party = _fieldVisitInfo.Party;
+            dischargeActivity.MeasurementId = !string.IsNullOrWhiteSpace(sxsSummary.Meas_No) ? sxsSummary.Meas_No.Trim() : null;
 
             //Mean gage height: 
             AddMeanGageHeight(dischargeActivity, sxsSummary.Stage, unitSystem);
@@ -86,6 +88,7 @@ namespace SxSPro.Mappers
 
             //Party: 
             manualGaugingDischarge.Party = dischargeActivity.Party;
+            manualGaugingDischarge.Comments = dischargeActivity.Comments;
 
             //Discharge method default to mid-section:
             var dischargeMethod = sxsSummary.Q_Method == "Mean-section"
@@ -93,6 +96,9 @@ namespace SxSPro.Mappers
                 : DischargeMethodType.MidSection;
 
             manualGaugingDischarge.DischargeMethod = dischargeMethod;
+            manualGaugingDischarge.StartPoint = sxsSummary.Begin_Shore == "Left"
+                ? StartPointType.LeftEdgeOfWater
+                : StartPointType.RightEdgeOfWater;
 
             return manualGaugingDischarge;
         }
@@ -105,7 +111,6 @@ namespace SxSPro.Mappers
             dischargeSection.AreaValue = sxsSummary.Meas_Area.AsDouble();
 
             //Width:
-            
             dischargeSection.WidthValue = sxsSummary.Meas_Width.AsDouble();
 
             //Velocity:

--- a/src/SxSPro/Mappers/DischargeActivityMapper.cs
+++ b/src/SxSPro/Mappers/DischargeActivityMapper.cs
@@ -16,6 +16,8 @@ namespace SxSPro.Mappers
     {
         private readonly FieldVisitInfo _fieldVisitInfo;
 
+        public bool IsMetric { get; private set; }
+
         public DischargeActivityMapper(FieldVisitInfo fieldVisitInfo)
         {
             _fieldVisitInfo = fieldVisitInfo;
@@ -24,7 +26,10 @@ namespace SxSPro.Mappers
         public DischargeActivity Map(XmlRootSummary xmlRootSummary)
         {
             var sxsSummary = xmlRootSummary.WinRiver_II_Section_by_Section_Summary;
-            var unitSystem = sxsSummary.Units_of_Measure == "Metric"
+
+            IsMetric = sxsSummary.Units_of_Measure == "Metric";
+
+            var unitSystem = IsMetric
                 ? Units.MetricUnitSystem
                 : Units.ImperialUnitSystem;
 

--- a/src/SxSPro/Mappers/DischargeActivityMapper.cs
+++ b/src/SxSPro/Mappers/DischargeActivityMapper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FieldDataPluginFramework.Context;
+﻿using FieldDataPluginFramework.Context;
 using FieldDataPluginFramework.DataModel;
 using FieldDataPluginFramework.DataModel.ChannelMeasurements;
 using FieldDataPluginFramework.DataModel.DischargeActivities;
@@ -80,6 +79,8 @@ namespace SxSPro.Mappers
             SetMappedVerticals(dischargeSection, meterCalibration, stations);
 
             SetChannelObservations(dischargeSection, sxsSummary, unitSystem);
+
+            dischargeSection.MeterCalibration = meterCalibration;
 
             dischargeActivity.ChannelMeasurements.Add(dischargeSection);
         }

--- a/src/SxSPro/Mappers/MeterCalibrationMapper.cs
+++ b/src/SxSPro/Mappers/MeterCalibrationMapper.cs
@@ -15,7 +15,7 @@ namespace SxSPro.Mappers
                 SerialNumber = sxsSummary.ADCP_Serial_No,
                 MeterType = MeterType.Adcp,
                 SoftwareVersion = sxsSummary.Software_Version,
-                Model = sxsSummary.Instrument,
+                Model = sxsSummary.Instrument?.Trim(),
                 Configuration = ComposeConfiguration(sxsSummary)
             };
         }

--- a/src/SxSPro/Mappers/ReadingsMapper.cs
+++ b/src/SxSPro/Mappers/ReadingsMapper.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using FieldDataPluginFramework.Context;
+using FieldDataPluginFramework.DataModel;
+using FieldDataPluginFramework.DataModel.Readings;
+using SxSPro.Schema;
+
+namespace SxSPro.Mappers
+{
+    public class ReadingsMapper
+    {
+        private readonly FieldVisitInfo _fieldVisitInfo;
+
+        public ReadingsMapper(FieldVisitInfo fieldVisitInfo)
+        {
+            _fieldVisitInfo = fieldVisitInfo;
+        }
+
+        public List<Reading> Map(XmlRootSummary sxsSummary, bool isMetric)
+        {
+            var readings = new List<Reading>();
+
+            AddTemperatureReading(readings, isMetric, "TW", sxsSummary.WinRiver_II_Section_by_Section_Summary.Water_Temp);
+            AddTemperatureReading(readings, isMetric, "TA", sxsSummary.WinRiver_II_Section_by_Section_Summary.Air_Temp);
+
+            return readings;
+        }
+
+        private void AddTemperatureReading(List<Reading> readings, bool isMetric, string parameterId, string value)
+        {
+            if (!double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var temperature))
+                return;
+
+            readings.Add(new Reading(parameterId, isMetric ? "degC" : "degF", temperature)
+            {
+                DateTimeOffset = _fieldVisitInfo.StartDate
+            });
+        }
+    }
+}

--- a/src/SxSPro/Mappers/VerticalMapper.cs
+++ b/src/SxSPro/Mappers/VerticalMapper.cs
@@ -37,8 +37,7 @@ namespace SxSPro.Mappers
             return new Vertical
             {
                 Segment = GetSegment(station),
-                //TODO: may need to look at ice thickness to determine which condition:
-                MeasurementConditionData = new OpenWaterData(),
+                MeasurementConditionData = CreateMeasurementCondition(station),
                 TaglinePosition = station.Dist.AsDouble(),
                 SequenceNumber = int.Parse(station.id),
                 MeasurementTime = GetMeasurementTime(station, lastStationId),
@@ -60,6 +59,23 @@ namespace SxSPro.Mappers
                 Width = station.Width.AsDouble(),
                 TotalDischargePortion = station.Percent_Tot.AsDouble()
             };
+        }
+
+        private MeasurementConditionData CreateMeasurementCondition(XmlRootSummaryStation station)
+        {
+            var isIce = station.WS_Btm_Of_Ice != 0
+                || station.WS_Btm_Of_Slush != 0
+                || station.Solid_Ice_Thickness != 0;
+
+            if (isIce)
+                return new IceCoveredData
+                {
+                    IceThickness = station.Solid_Ice_Thickness.AsDouble(),
+                    WaterSurfaceToBottomOfIce = station.WS_Btm_Of_Ice.AsDouble(),
+                    WaterSurfaceToBottomOfSlush = station.WS_Btm_Of_Slush.AsDouble()
+                };
+
+            return new OpenWaterData();
         }
 
         private DateTimeOffset? GetMeasurementTime(XmlRootSummaryStation station, string lastStationId)

--- a/src/SxSPro/Parser.cs
+++ b/src/SxSPro/Parser.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using FieldDataPluginFramework;
 using FieldDataPluginFramework.Context;
 using FieldDataPluginFramework.Results;
@@ -31,7 +33,8 @@ namespace SxSPro
 
         private FieldVisitInfo AppendMappedFieldVisitInfo(XmlRootSummary summary, LocationInfo locationInfo)
         {
-            var mapper = new FieldVisitMapper(summary, _location);
+            var config = new ConfigLoader().Load(GetConfigurationPath());
+            var mapper = new FieldVisitMapper(config, summary, _location);
             var fieldVisitDetails = mapper.MapFieldVisitDetails();
 
             _logger.Info($"Successfully parsed one visit '{fieldVisitDetails.FieldVisitPeriod}' " +
@@ -40,6 +43,11 @@ namespace SxSPro
             return _appender.AddFieldVisit(locationInfo, fieldVisitDetails);
         }
 
+        private string GetConfigurationPath()
+        {
+            // ReSharper disable once AssignNullToNotNullAttribute
+            return Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location), $"{nameof(Config)}.json");
+        }
         private void AppendMappedMeasurements(XmlRootSummary xmlRootSummary, FieldVisitInfo fieldVisitInfo)
         {
             var dischargeActivityMapper = new DischargeActivityMapper(fieldVisitInfo);

--- a/src/SxSPro/Parser.cs
+++ b/src/SxSPro/Parser.cs
@@ -48,11 +48,18 @@ namespace SxSPro
             // ReSharper disable once AssignNullToNotNullAttribute
             return Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location), $"{nameof(Config)}.json");
         }
+
         private void AppendMappedMeasurements(XmlRootSummary xmlRootSummary, FieldVisitInfo fieldVisitInfo)
         {
             var dischargeActivityMapper = new DischargeActivityMapper(fieldVisitInfo);
 
             _appender.AddDischargeActivity(fieldVisitInfo, dischargeActivityMapper.Map(xmlRootSummary));
+
+            var readingsMapper = new ReadingsMapper(fieldVisitInfo);
+            foreach (var reading in readingsMapper.Map(xmlRootSummary, dischargeActivityMapper.IsMetric))
+            {
+                _appender.AddReading(fieldVisitInfo, reading);
+            }
         }
     }
 }

--- a/src/SxSPro/Readme.md
+++ b/src/SxSPro/Readme.md
@@ -1,0 +1,142 @@
+﻿# SxS Pro Field Data Plugin
+
+How do you know if the plugin is configured correctly?
+
+Try parsing a file measured on the 13th day of a month or later. If you are happy with the parsed visit, then your configuration is good.
+
+Using a file with a "13" or higher for the day value will immediately detect a format problem if the expected month & day columns are swapped.
+
+## Configuring the plugin
+
+The format of SxS Pro XML files consumed by this plugin can vary from based on the SxS Pro user's regional settings for times and dates.
+
+The SxS Pro software will generate different XML for US users vs. UK users.
+
+Consider April Fool's Day, 2019 (an example date which ironically exposes the foolish bug).
+
+US XML files will contain `<Date>4/1/2019</Date>`, but XML files saved in Great Britain wil contain `<Date>01/04/2019</Date>`.
+
+Since the plugin runs on the AQTS server, it does not know which date format to expect, so the plugin must be configured with what to expect.
+
+Should it prefer month/day/year (US-style) or day/month/year (UK-style)?
+
+### Choose a standard date/time format for your agency!
+
+Windows systems provide [quite a variety of options](https://www.basicdatepicker.com/samples/cultureinfo.aspx), so make sure your technicians know which regional settings to use when exporting XML from SxS Pro.
+
+To make matters worse, Fred could be running on a UK version of Windows 10, which defaults to "dd/MM/yyyy" but Fred could have changed his regional settings to Czech, which uses "d. M. yyyy". Any SxS Pro XML file that Fred's computer exports would have `<Date>1. 4. 2019</Date>`.
+
+Yeah, it's a pretty gross problem to contain. But if you need to ingest SxS measurements reliably, you will need to standardize how your files are prepared.
+
+## How to inspect your XML file:
+
+There are two nodes in the `<WinRiver_II_Section_by_Section_Summary>` node near the top of the file:
+
+The `<Date>` and `<Start_End_Time>` nodes contain dates and times which will be influenced by the current Windows regional settings when the files are exported from SxS Pro software.
+
+Here is the start of a typical SxS Pro XML file, with the relevant nodes:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<XmlRoot>
+  <Summary>
+    <WinRiver_II_Section_by_Section_Summary>
+      <Site_Name>Logan Creek near Uehling</Site_Name>
+      <Printed_Date>11/29/2019</Printed_Date>
+      <Station_No>6799500</Station_No>
+      <Air_Temp>-</Air_Temp>
+      <River_Name></River_Name>
+      <Location></Location>
+      <Date>11/6/2019</Date>
+      <Start_End_Time>12:44:55 PM/1:08:51 PM</Start_End_Time>
+      <Party>LLG JDH JJV</Party>
+      <Software_Ver>1.00</Software_Ver>
+      <Units_of_Measure>English</Units_of_Measure>
+      <Meas_No>3</Meas_No>
+      <No_Stations>25</No_Stations>
+```
+
+In this example we can tell from `<Printed_Date>` that a "M/d/yyyy" format was used, since a month value of 29 makes no sense.
+
+## The `Config.json` file stores the plugin's configuration
+
+The `Config.json` file lives in the same folder as the plugin.
+
+`%ProgramData%\Aquatic Informatics\AQUARIUS Server\FieldDataPlugins\SxsPro\Config.json`
+
+This JSON file is re-read from disk each time a SxS file is uploaded to AQTS for parsing. Updates to the file will take effect on the next SxS file parsed.
+
+The JSON configuration information stores two settings:
+
+| Property Name | Description |
+| --- | --- |
+| **DateFormats** | A list of date format format strings, used to parse the `<Date>` node. |
+| **TimeFormats** | A list of time format format strings, used to parse the `<Start_End_Time>` node. |
+
+The first format string to match a date or time is used.
+
+By default, the plugin assumes US regional settings for dates and times, plus ISO 8601 for dates.
+
+```json
+{
+  "DateFormats": [ "M/d/yyyy", "M-d-yyyy", "yyyy/M/d", "yyyy-M-d" ],
+  "TimeFormats": [ "h:m:s tt", "h:m tt", "H:m:s", "H:m" ]
+}
+```
+
+Notes:
+- Editing JSON files [can be tricky](#json-editing-tips). Don't include a trailing comma after the last item in the list.
+- Date format strings should only include uppercase `M` (month) patterns, not lowercase `m` (minute) patterns.
+- Date format lists should not be ambiguous. Don't include both a day+month pattern and a month+day pattern.
+- Time format lists should not be ambiguous. Each pattern should include both lowercase `h` (12-hour) and `tt` (AM/PM designator), or should use uppercase `H` (24-hour) and no `tt` pattern at all.
+
+## Tips about `Format` strings:
+`Format` values are [.NET custom date/time format strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings).
+
+These format strings can be rather fussy to deal with, so take care to consider some of the common edge cases:
+- Format strings are case-sensitive. Common mistakes are made for month-vs-minute and 24-hour-vs-12-hour patterns.
+- Uppercase ['M'](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#M_Specifier) matches month digits, between 1 and 12.
+- Lowercase ['m'](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#mSpecifier) matches minute digits, between 0 and 59.
+- Uppercase ['H'](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#H_Specifier) matches 24-hour hour digits, between 0 and 23.
+- Lowercase ['h'](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#hSpecifier) matches 12-hour hour digits, between 1 and 12, and require a ['t' or 'tt'](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#tSpecifier) pattern to distinguish AM from PM.
+- Prefer single-character patterns when possible, since they match double-digit values as well. Eg. 'H:m' will match '2:35' and '14:35', but 'HH:mm" will not match '2:35' since the 'HH' means exactly-2-digits.
+
+## JSON editing tips
+
+Editing [JSON](https://json.org) can be a tricky thing.
+
+Sometimes the plugin code can detect a poorly formatted JSON document and report a decent error, but sometimes a poorly formatted JSON document will appear to the plugin as just an empty document.
+
+Here are some tips to help eliminate common JSON config errors:
+- Edit JSON in a real text editor. Notepad is fine, [Notepad++](https://notepad-plus-plus.org/) or [Visual Studio Code](https://code.visualstudio.com/) are even better choices.
+- Don't try editing JSON in Microsoft Word. Word will mess up your quotes and you'll just have a bad time.
+- Try validating your JSON using the online [JSONLint validator](https://jsonlint.com/).
+- Whitespace between items is ignored. Your JSON document can be single (but very long!) line, but the convention is separate items on different lines, to make the text file more readable.
+- All property names must be enclosed in double-quotes (`"`). Don't use single quotes (`'`) or smart quotes (`“` or `”`), which are actually not that smart for JSON!
+- Avoid a trailing comma in lists. JSON is very fussy about using commas **between** list items, but rejects lists when a trailing comma is included. Only use a comma to separate items in the middle of a list.
+
+### Adding comments to JSON
+
+The JSON spec doesn't support comments, which is unfortunate.
+
+However, the code will simply skip over properties it doesn't care about, so a common trick is to add a dummy property name/value string. The code won't care or complain, and you get to keep some notes close to other special values in your custom JSON document.
+
+Instead of this:
+
+```json
+{
+  "ExpectedPropertyName": "a value",
+  "AnotherExpectedProperty": 12.5 
+}
+```
+
+Try this:
+
+```json
+{
+  "_comment_": "Don't enter a value below 12, otherwise things break",
+  "ExpectedPropertyName": "a value",
+  "AnotherExpectedProperty": 12.5 
+}
+```
+
+Now your JSON has a comment to help you remember why you chose the `12.5` value.

--- a/src/SxSPro/SxSPro.csproj
+++ b/src/SxSPro/SxSPro.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SxSPro</RootNamespace>
     <AssemblyName>SxSPro</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -35,8 +35,8 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FieldDataPluginFramework, Version=1.2.0.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\Aquarius.FieldDataFramework.18.2.0\lib\net47\FieldDataPluginFramework.dll</HintPath>
+    <Reference Include="FieldDataPluginFramework, Version=2.3.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\Aquarius.FieldDataFramework.19.2.2\lib\net472\FieldDataPluginFramework.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
@@ -79,7 +79,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.18.2.0\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin
-$(SolutionDir)packages\Aquarius.FieldDataFramework.18.2.0\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\SxSProDischargeSummary.xml</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)packages\Aquarius.FieldDataFramework.19.2.2\tools\PluginPackager.exe $(TargetPath) /OutputPath=$(ProjectDir)deploy\$(Configuration)\$(TargetName).plugin
+$(SolutionDir)packages\Aquarius.FieldDataFramework.19.2.2\tools\PluginTester.exe /Plugin=$(TargetPath) /Data=$(SolutionDir)..\data\SxSProDischargeSummary.xml</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/SxSPro/SxSPro.csproj
+++ b/src/SxSPro/SxSPro.csproj
@@ -38,12 +38,17 @@
     <Reference Include="FieldDataPluginFramework, Version=1.2.0.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\Aquarius.FieldDataFramework.18.2.0\lib\net47\FieldDataPluginFramework.dll</HintPath>
     </Reference>
+    <Reference Include="ServiceStack.Text, Version=4.5.12.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.4.5.12\lib\net45\ServiceStack.Text.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config.cs" />
+    <Compile Include="ConfigLoader.cs" />
     <Compile Include="Helper\DecimalExtensions.cs" />
     <Compile Include="Mappers\MeterCalibrationMapper.cs" />
     <Compile Include="Mappers\VerticalMapper.cs" />
@@ -60,7 +65,11 @@
     <Compile Include="SystemCode\Units.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Config.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
+    <None Include="Readme.md" />
     <None Include="Schema\SxSDischargeSummary.xsd">
       <SubType>Designer</SubType>
     </None>

--- a/src/SxSPro/SxSPro.csproj
+++ b/src/SxSPro/SxSPro.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ConfigLoader.cs" />
     <Compile Include="Helper\DecimalExtensions.cs" />
     <Compile Include="Mappers\MeterCalibrationMapper.cs" />
+    <Compile Include="Mappers\ReadingsMapper.cs" />
     <Compile Include="Mappers\VerticalMapper.cs" />
     <Compile Include="Mappers\DischargeActivityMapper.cs" />
     <Compile Include="Mappers\FieldVisitMapper.cs" />

--- a/src/SxSPro/packages.config
+++ b/src/SxSPro/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Aquarius.FieldDataFramework" version="18.2.0" targetFramework="net47" />
+  <package id="Aquarius.FieldDataFramework" version="19.2.2" targetFramework="net472" />
   <package id="ServiceStack.Text" version="4.5.12" targetFramework="net47" />
 </packages>

--- a/src/SxSPro/packages.config
+++ b/src/SxSPro/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Aquarius.FieldDataFramework" version="18.2.0" targetFramework="net47" />
+  <package id="ServiceStack.Text" version="4.5.12" targetFramework="net47" />
 </packages>

--- a/src/SxSProPlugin.sln
+++ b/src/SxSProPlugin.sln
@@ -11,6 +11,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RepoRoot", "RepoRoot", "{67
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data", "data", "{1AD01D42-F42F-4403-AEA9-0079CF38FF61}"
+	ProjectSection(SolutionItems) = preProject
+		..\data\SxSProDischargeSummary.xml = ..\data\SxSProDischargeSummary.xml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,6 +29,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1AD01D42-F42F-4403-AEA9-0079CF38FF61} = {67D86BD9-E248-4972-BC34-6827FB601BFE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5ED429BB-6757-4D5E-A398-83BCC633043D}


### PR DESCRIPTION
The plugin's expected date and time format is now configurable with a `Config.json`  which lives in the plugin folder.

The plugin defaults to US regional settings (M/d/yyyy) and ISO 8601 settings (yyyy-M-d)